### PR TITLE
Generic plugin configuration

### DIFF
--- a/pkg/apis/vernemq/v1alpha1/vernemq_types.go
+++ b/pkg/apis/vernemq/v1alpha1/vernemq_types.go
@@ -116,6 +116,12 @@ type Plugin struct {
 	Name string `json:"name"`
 	// The path to the plugin application
 	Path string `json:"path,omitempty"`
+	// The name of the configmap for the plugin
+	Config string `json:"config,omitempty"`
+	// The name of the module used to apply the configuration from
+	// the configmap, if not specified `name` is used as the
+	// module name.
+	ConfigMod string `json:"configMod,omitempty"`
 }
 
 // ConfigItem defines a single reloadable VerneMQ config item

--- a/pkg/apis/vernemq/v1alpha1/vernemq_types.go
+++ b/pkg/apis/vernemq/v1alpha1/vernemq_types.go
@@ -116,11 +116,11 @@ type Plugin struct {
 	Name string `json:"name"`
 	// The path to the plugin application
 	Path string `json:"path,omitempty"`
-	// The name of the configmap for the plugin
+	// The (opaque) config string which is passed directly to the
+	// plugin where it is applied.
 	Config string `json:"config,omitempty"`
-	// The name of the module used to apply the configuration from
-	// the configmap, if not specified `name` is used as the
-	// module name.
+	// The name of the module used to apply the configuration, if
+	// not specified `name` is used as the module name.
 	ConfigMod string `json:"configMod,omitempty"`
 }
 

--- a/pkg/controller/vernemq/statefulset.go
+++ b/pkg/controller/vernemq/statefulset.go
@@ -3,7 +3,6 @@ package vernemq
 import (
 	"encoding/base64"
 	"fmt"
-	"strings"
 
 	"github.com/blang/semver"
 	pkgerr "github.com/pkg/errors"
@@ -286,35 +285,6 @@ func makeStatefulSetSpec(instance *vernemqv1alpha1.VerneMQ) (*appsv1.StatefulSet
 			ReadOnly:  true,
 			MountPath: configmapsDir + c,
 		})
-
-	}
-
-	// make plugin configmaps available in the container
-	envConfigMaps := []v1.EnvVar{}
-	for _, p := range instance.Spec.Config.Plugins {
-		if p.Config != "" {
-			n := p.Name
-			c := p.Config
-			envConfigMaps = append(envConfigMaps, v1.EnvVar{
-				Name:  "VMQ_PLUGIN_" + strings.ToUpper(n),
-				Value: fmt.Sprintf("%s/%s/config", configmapsDir, c),
-			})
-			volumes = append(volumes, v1.Volume{
-				Name: volumeName("configmap-" + c),
-				VolumeSource: v1.VolumeSource{
-					ConfigMap: &v1.ConfigMapVolumeSource{
-						LocalObjectReference: v1.LocalObjectReference{
-							Name: c,
-						},
-					},
-				},
-			})
-			vernemqVolumeMounts = append(vernemqVolumeMounts, v1.VolumeMount{
-				Name:      volumeName("configmap-" + c),
-				ReadOnly:  true,
-				MountPath: configmapsDir + c,
-			})
-		}
 	}
 
 	var livenessFailureThreshold int32 = 60
@@ -374,7 +344,7 @@ func makeStatefulSetSpec(instance *vernemqv1alpha1.VerneMQ) (*appsv1.StatefulSet
 	}
 
 	additionalContainers := instance.Spec.Containers
-	envVars := append(instance.Spec.Env, envConfigMaps...)
+	envVars := instance.Spec.Env
 
 	return &appsv1.StatefulSetSpec{
 		ServiceName:         serviceName(instance.Name),


### PR DESCRIPTION
This PR is small, but distills about a weeks worth of gettting up to speed with k8s and operators. The purpose of the PR is to create a generic way to configure VerneMQ plugins. One goal was that no plugin specific logic is allowed in `vmq_k8s_reloader`, and therefore the approach is very simple. Namely simply passing an opaque string to a function in the plugin and it is then up to the plugin to parse/verify/apply the configuration.

For official plugins which ship as part of VerneMQ we could build the appropriate types and expose the configuration directly. This would have the benefit that we'd be able to type check the yaml directly. The drawback is that that isn't a generic solution. So instead, I decided that if we could pass in an opaque string, then in the case of a plugin shipping with VerneMQ we should pass in a configuration matching exactly what one would have otherwise put into the `vernemq.conf` file. An example would be the `vmq_webhooks` plugin, which would then be configured as follows:

```yaml
apiVersion: vernemq.com/v1alpha1
kind: VerneMQ
metadata:
  labels:
    vernemq: k8s
  name: k8s
  namespace: messaging

spec:
  baseImage: erlio/docker-vernemq
  config:
    plugins:
    - name: vmq_webhooks
      configMod: vmq_webhooks_app
      config: |
        vmq_webhooks.hook1.endpoint=someurl
        vmq_webhooks.hook1.hook=auth_on_register
        vmq_webhooks.hook1.base64encode=on

  serviceAccountName: vernemq-k8s
  size: 1
  version: 1.8.0
```

In an earlier version I'd put the config into a configMap, but this introduces more moving parts and I decided to go with this simpler version for now.

In the vernemq/vernemq#1220 PR the webhook plugin has been adapted to be able to reload it's config from the config string above.