### PR TITLE
Configure plugins via command hooks

### DIFF
--- a/erlang/src/vmq_k8s_reloader.erl
+++ b/erlang/src/vmq_k8s_reloader.erl
@@ -196,7 +196,7 @@ exec_commands([CmdConfig|Rest]) ->
             false -> ""
         end,
     Res = os:cmd([Cmd, Redirect]),
-    lager:info("Execute \"~s ~s\" \"~s\"", [Cmd, Redirect, Res]),
+    lager:info("Execute \"~s ~s\" \"~s\"", [Cmd, Redirect, string:trim(Res)]),
     exec_commands(Rest).
 
 to_snake_case(S) ->

--- a/erlang/src/vmq_k8s_reloader.erl
+++ b/erlang/src/vmq_k8s_reloader.erl
@@ -195,7 +195,8 @@ exec_commands([CmdConfig|Rest]) ->
             true -> " 2>&1";
             false -> ""
         end,
-    os:cmd([Cmd, Redirect]),
+    Res = os:cmd([Cmd, Redirect]),
+    lager:info("Execute \"~s ~s\" \"~s\"", [Cmd, Redirect, Res]),
     exec_commands(Rest).
 
 to_snake_case(S) ->

--- a/erlang/src/vmq_k8s_reloader.erl
+++ b/erlang/src/vmq_k8s_reloader.erl
@@ -164,7 +164,7 @@ apply_plugins_config([PluginConfig|Rest], Acc, CurrentState) ->
                             command(["plugin", "enable", "-n", Name, "-p", Path],
                                     succf({plugin, Name}, PluginConfig), Acc)
                     end,
-                    PostCmds = proplists:get_value("preStart", PluginConfig, []),
+                    PostCmds = proplists:get_value("postStart", PluginConfig, []),
                     ok = exec_commands(PostCmds),
                     apply_plugins_config(Rest, Acc1, CurrentState)
             end
@@ -178,7 +178,7 @@ apply_plugins_config([], NewState, OldState) ->
                           PreCmds = proplists:get_value("preStop", Cfg, []),
                           exec_commands(PreCmds),
                           command(["plugin", "disable", "-n", Name]),
-                          PostCmds = proplists:get_value("preStop", Cfg, []),
+                          PostCmds = proplists:get_value("postStop", Cfg, []),
                           exec_commands(PostCmds)
                   end, ToBeDisabled),
     NewState;

--- a/erlang/src/vmq_k8s_reloader.erl
+++ b/erlang/src/vmq_k8s_reloader.erl
@@ -203,7 +203,7 @@ exec_commands([CmdConfig|Rest]) ->
             demonitor(MRef, [flush]),
             lager:info("Execute \"~s\" \"~s\"", [Cmd, string:trim(Res)]);
         {'DOWN', MRef, process, _, Info} ->
-            lager:info("Execute \"~s\" abnormally terminated (~ps)", [Cmd, Info])
+            lager:info("Execute \"~s\" abnormally terminated (~p)", [Cmd, Info])
     after
         TimeoutMs ->
             exit(Pid, kill),
@@ -212,8 +212,10 @@ exec_commands([CmdConfig|Rest]) ->
                 {exec_cmd_res, Ref, Cmd, Res} ->
                     demonitor(MRef, [flush]),
                     lager:info("Execute \"~s\" \"~s\"", [Cmd, string:trim(Res)]);
-                {'DOWN', MRef, process, _, Info} ->
-                    lager:info("Execute \"~s\" abnormally terminated (~ps)", [Cmd, Info])
+                {'DOWN', MRef, process, _, killed=Info} ->
+                    lager:info("Execute \"~s\" abnormally terminated (~p)", [Cmd, Info]);
+                {'DOWN', MRef, process, _, _} ->
+                    lager:info("Execute \"~s\" aborted due to timeout (~ps)", [Cmd, TimeoutSeconds])
             end
     end,
     exec_commands(Rest).

--- a/erlang/src/vmq_k8s_reloader.erl
+++ b/erlang/src/vmq_k8s_reloader.erl
@@ -174,7 +174,7 @@ apply_plugins_config([], NewState, OldState) ->
     Old = [Name || {plugin, Name} <- maps:keys(OldState)],
     ToBeDisabled = Old -- New,
     lists:foreach(fun(Name) ->
-                          Cfg = maps:get(OldState, {plugin, Name}),
+                          Cfg = maps:get({plugin, Name}, OldState, []),
                           PreCmds = proplists:get_value("preStop", Cfg, []),
                           exec_commands(PreCmds),
                           command(["plugin", "disable", "-n", Name]),

--- a/erlang/src/vmq_k8s_reloader.erl
+++ b/erlang/src/vmq_k8s_reloader.erl
@@ -190,13 +190,8 @@ exec_commands([]) -> ok;
 exec_commands([CmdConfig|Rest]) ->
     _TimeoutSeconds = proplists:get_value("timeoutSeconds", CmdConfig, 5),
     Cmd = proplists:get_value("cmd", CmdConfig),
-    Redirect =
-        case proplists:get_value("redirectStderr", CmdConfig, true) of
-            true -> " 2>&1";
-            false -> ""
-        end,
-    Res = os:cmd([Cmd, Redirect]),
-    lager:info("Execute \"~s ~s\" \"~s\"", [Cmd, Redirect, string:trim(Res)]),
+    Res = os:cmd(Cmd),
+    lager:info("Execute \"~s\" \"~s\"", [Cmd, string:trim(Res)]),
     exec_commands(Rest).
 
 to_snake_case(S) ->

--- a/erlang/src/vmq_k8s_reloader.erl
+++ b/erlang/src/vmq_k8s_reloader.erl
@@ -212,10 +212,10 @@ exec_commands([CmdConfig|Rest]) ->
                 {exec_cmd_res, Ref, Cmd, Res} ->
                     demonitor(MRef, [flush]),
                     lager:info("Execute \"~s\" \"~s\"", [Cmd, string:trim(Res)]);
-                {'DOWN', MRef, process, _, killed=Info} ->
-                    lager:info("Execute \"~s\" abnormally terminated (~p)", [Cmd, Info]);
-                {'DOWN', MRef, process, _, _} ->
-                    lager:info("Execute \"~s\" aborted due to timeout (~ps)", [Cmd, TimeoutSeconds])
+                {'DOWN', MRef, process, _, killed} ->
+                    lager:info("Execute \"~s\" aborted due to timeout (~ps)", [Cmd, TimeoutSeconds]);
+                {'DOWN', MRef, process, _, Info} ->
+                    lager:info("Execute \"~s\" abnormally terminated (~p)", [Cmd, Info])
             end
     end,
     exec_commands(Rest).

--- a/pkg/apis/vernemq/v1alpha1/vernemq_types.go
+++ b/pkg/apis/vernemq/v1alpha1/vernemq_types.go
@@ -130,8 +130,8 @@ type Command struct {
 	// Command to be executed
 	Command string `json:"cmd"`
 	// Number of seconds after which the command times
-	// out. Defaults to 5 seconds. Minimum value is 1.
-	TimeoutSeconds int `json:"timeoutSeconds"`
+	// out. Defaults to 5 seconds.
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 }
 
 // ConfigItem defines a single reloadable VerneMQ config item

--- a/pkg/apis/vernemq/v1alpha1/vernemq_types.go
+++ b/pkg/apis/vernemq/v1alpha1/vernemq_types.go
@@ -132,8 +132,6 @@ type Command struct {
 	// Number of seconds after which the command times
 	// out. Defaults to 5 seconds. Minimum value is 1.
 	TimeoutSeconds int `json:"timeoutSeconds"`
-	// Redirect StdErr to StdOut. Defaults to true.
-	Redirect bool `json:"redirectStdErr"`
 }
 
 // ConfigItem defines a single reloadable VerneMQ config item

--- a/pkg/apis/vernemq/v1alpha1/vernemq_types.go
+++ b/pkg/apis/vernemq/v1alpha1/vernemq_types.go
@@ -116,6 +116,24 @@ type Plugin struct {
 	Name string `json:"name"`
 	// The path to the plugin application
 	Path string `json:"path,omitempty"`
+	// Commands to execute before the plugin is started
+	PreStart []Command `json:"preStart,omitempty"`
+	// Commands to execute after the plugin is started
+	PostStart []Command `json:"postStart,omitempty"`
+	// Commands to execute before the plugin is stopped
+	PreStop []Command `json:"preStop,omitempty"`
+	// Commands to execute after the plugin is stopped
+	PostStop []Command `json:"postStop,omitempty"`
+}
+
+type Command struct {
+	// Command to be executed
+	Command string `json:"cmd"`
+	// Number of seconds after which the command times
+	// out. Defaults to 5 seconds. Minimum value is 1.
+	TimeoutSeconds int `json:"timeoutSeconds"`
+	// Redirect StdErr to StdOut. Defaults to true.
+	Redirect bool `json:"redirectStdErr"`
 }
 
 // ConfigItem defines a single reloadable VerneMQ config item


### PR DESCRIPTION
Make plugins configurable via command hooks. Like this:

```yaml
    plugins:
    - name: vmq_webhooks
      preStart:
        - cmd: echo preStart
          timeoutSeconds: 15
      postStart:
        - cmd: vmq-admin webhooks register hook=auth_on_register endpoint=http://0.0.0.0:8080/
        - cmd: vmq-admin webhooks register hook=auth_on_publish endpoint=http://0.0.0.0:8080/
      preStop:
        - cmd: echo preStop
      postStop:
        - cmd: echo postStop
```

Which results in the following in the logs when starting the pod:
```
11:40:41.638 [info] Execute "echo preStart" "preStart"
11:40:41.797 [info] Execute: ["vmq-admin","plugin","enable","-n","vmq_webhooks"] "Done"
11:40:42.280 [info] Execute "vmq-admin webhooks register hook=auth_on_register endpoint=http://0.0.0.0:8080/" "Done"
11:40:42.762 [info] Execute "vmq-admin webhooks register hook=auth_on_publish endpoint=http://0.0.0.0:8080/" "Done"
```

