### PR TITLE
Change jsonnet api version also in jsonnet file not only in generated yaml

### DIFF
--- a/jsonnet/vmq-operator/vmq-operator.libsonnet
+++ b/jsonnet/vmq-operator/vmq-operator.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
 {
   _config+:: {
@@ -85,8 +85,8 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       role.withRules(rules),
    
     deployment:
-      local deployment = k.apps.v1beta2.deployment;
-      local container = k.apps.v1beta2.deployment.mixin.spec.template.spec.containersType;
+      local deployment = k.apps.v1.deployment;
+      local container = k.apps.v1.deployment.mixin.spec.template.spec.containersType;
       
       local operatorContainer =
         container.new('vmq-operator', $._config.imageRepos.vernemqOperator + ':' + $._config.versions.vernemqOperator) +


### PR DESCRIPTION
There was a fix to set the deployment on the correct api version. But it was only an change in the yaml-files. While using the jsonnet to generate, do it still wrong. this shoud fix it